### PR TITLE
feat: add spell checker for both 'en' and 'pt-br'

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -448,6 +448,7 @@
         "plenary.nvim": "plenary.nvim",
         "satellite.nvim": "satellite.nvim",
         "snacks.nvim": "snacks.nvim",
+        "spellwarn.nvim": "spellwarn.nvim",
         "which-key.nvim": "which-key.nvim"
       }
     },
@@ -480,6 +481,22 @@
       "original": {
         "owner": "folke",
         "repo": "snacks.nvim",
+        "type": "github"
+      }
+    },
+    "spellwarn.nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1756861421,
+        "narHash": "sha256-c7pjWmhRqNAuJ2rq4lsrFLEM9Ypdi7eUQ08CCqXl9M0=",
+        "owner": "ravibrock",
+        "repo": "spellwarn.nvim",
+        "rev": "ef6a121b2fec1c4474427c6ccfd489338eb53a5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ravibrock",
+        "repo": "spellwarn.nvim",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
-
   outputs = {
     self,
     nixpkgs,
@@ -160,6 +159,10 @@
       url = "github:NeogitOrg/neogit";
       flake = false;
     };
+    "noice.nvim" = {
+      url = "github:folke/noice.nvim";
+      flake = false;
+    };
     "nui.nvim" = {
       url = "github:MunifTanjim/nui.nvim";
       flake = false;
@@ -208,13 +211,12 @@
       url = "github:folke/snacks.nvim";
       flake = false;
     };
-    "which-key.nvim" = {
-      url = "github:folke/which-key.nvim";
+    "spellwarn.nvim" = {
+      url = "github:ravibrock/spellwarn.nvim";
       flake = false;
     };
-
-    "noice.nvim" = {
-      url = "github:folke/noice.nvim";
+    "which-key.nvim" = {
+      url = "github:folke/which-key.nvim";
       flake = false;
     };
   };

--- a/lua/plugins/spellwarn.lua
+++ b/lua/plugins/spellwarn.lua
@@ -1,0 +1,53 @@
+-- Those are the default options provided at the
+
+local default_opts = {
+    event = { -- event(s) to refresh diagnostics on
+        "CursorHold",
+        "InsertLeave",
+        "TextChanged",
+        "TextChangedI",
+        "TextChangedP",
+    },
+    enable = true, -- enable diagnostics on startup
+    ft_config = { -- spellcheck method: "cursor", "iter", or boolean
+        alpha = false,
+        help = false,
+        lazy = false,
+        lspinfo = false,
+        mason = false,
+    },
+    ft_default = true, -- default option for unspecified file types
+    max_file_size = nil, -- maximum file size to check in lines (nil for no limit)
+    severity = { -- severity for each spelling error type (false to disable diagnostics for that type)
+        spellbad = "WARN",
+        spellcap = "HINT",
+        spelllocal = "HINT",
+        spellrare = "INFO",
+    },
+    suggest = false, -- show spelling suggestions in diagnostic message (works best with window-style message)
+    num_suggest = 3, -- number of spelling suggestions shown in diagnostic message
+    prefix = "possible misspelling(s): ", -- prefix for each diagnostic message
+    diagnostic_opts = { severity_sort = true }, -- options for diagnostic display
+}
+
+local function config()
+    -- enable spell checking for English and Portuguese
+    -- Usage:
+    -- ]s            -> jump to next misspelled word
+    -- [s            -> jump to previous misspelled word
+    -- z=            -> show spelling suggestions
+    -- zg            -> add word to dictionary
+    -- zw            -> mark word as wrong
+    -- :set spell!   -> toggle spell checking
+    vim.opt.spell = true
+    vim.opt.spelllang = { "en_us", "pt_br" }
+
+    require("spellwarn").setup(default_opts)
+end
+
+return {
+    "ravibrock/spellwarn.nvim",
+    lazy = false,
+    priority = 1501,
+    config = config,
+}


### PR DESCRIPTION
the plugin `spellwarn` was added, and set to support
both english and portuguese (Brazil), the flake was
also update to include the new plugin.
